### PR TITLE
Update $pesticide-debug variable to be overridable

### DIFF
--- a/sass/pesticide.scss
+++ b/sass/pesticide.scss
@@ -2,7 +2,7 @@
     pesticide v0.1.0 . @mrmrs . MIT
 */
 
-$pesticide-debug: true;
+$pesticide-debug: true !default;
 
 @if $pesticide-debug == true {
 


### PR DESCRIPTION
Allow the $pesticide-debug variable to be overridable, so that someone can specify a false value before they include this sass file to disable it.
