### PR TITLE
Injected CSS with insertCSS

### DIFF
--- a/pesticide_for_chrome/pesticide.js
+++ b/pesticide_for_chrome/pesticide.js
@@ -1,8 +1,5 @@
 // Called when the user clicks on the browser action.
 
 chrome.browserAction.onClicked.addListener(function(tab) {
-    
-    chrome.tabs.executeScript({
-        code: 'var pesticideLink; (document.getElementById("pesticide") == null) ? (pesticideLink = document.createElement("link"), pesticideLink.href = chrome.extension.getURL("/pesticide.min.css"), pesticideLink.id = "pesticide", pesticideLink.type = "text/css", pesticideLink.rel = "stylesheet",document.getElementsByTagName("head")[0].appendChild(pesticideLink)) : (document.getElementsByTagName("head")[0].removeChild(document.getElementById("pesticide")))'
-    });
+    chrome.tabs.insertCSS({file: 'pesticide.min.css'});
 });


### PR DESCRIPTION
Using `insertCSS` instead of `executeScript` seems to be proper.
Moreover, you may also want to remove `"web_accessible_resources": [ "pesticide.min.css" ]` from your manifest.
