### PR TITLE
support pseudo-elements in pesticide?

### DIFF
--- a/css/pesticide.css
+++ b/css/pesticide.css
@@ -198,4 +198,8 @@ br
   outline: 1px solid #db687d !important;
 wbr
   outline: 1px solid #db175b !important;
+:before
+  outline: 1px solid #2980b9 !important;
+:after
+  outline: 1px solid #2980b9 !important;
 }

--- a/less/pesticide.less
+++ b/less/pesticide.less
@@ -105,6 +105,8 @@
 	span { outline: 1px solid #cc2643 !important; }
 	br { outline: 1px solid #db687d !important; }
 	wbr { outline: 1px solid #db175b !important; }
+	:before { outline: 1px solid #2980b9 !important; }
+	:after { outline: 1px solid #2980b9 !important; }
 }
 
 & when (@pesticide-debug-depth = true) {

--- a/sass/pesticide.scss
+++ b/sass/pesticide.scss
@@ -105,6 +105,8 @@ $pesticide-debug-depth: true !default;
   span { outline: 1px solid #cc2643 !important; }
   br { outline: 1px solid #db687d !important; }
   wbr { outline: 1px solid #db175b !important; }
+  :before { outline: 1px solid #2980b9 !important; }
+  :after { outline: 1px solid #2980b9 !important; }
 }
 
 @if $pesticide-debug-depth == true {

--- a/stylus/pesticide.styl
+++ b/stylus/pesticide.styl
@@ -203,3 +203,7 @@ if pesticide-debug-outline
 		outline 1px solid #db687d !important
   wbr
 		outline 1px solid #db175b !important
+  :before
+		outline: 1px solid #2980b9 !important;
+  :after
+		outline: 1px solid #2980b9 !important;


### PR DESCRIPTION
this is a naive changeset in the interest of support for pseudo-elements in
pesticide. it's not ready to be pulled in, but I wanted to get a little
bit of discussion going. here are the notes:

1. this changeset only adds `outline` support. to fully support
pseudoelements, you'd probably want to add depth rules for `before` and
`after` too.

2. didn't mess with `color_table.json`. should there be entries there
for `before` and `after` too?

3. I manually added rulesets for stylus, less, and scss. this is a
fairly-complete, awesome library, but what's the best process to follow
when a change does need to be introduced? (i.e., of the steps I've taken
here, what's missing?)

4. looks like the current `css/pesticide.css` is actually a stylus
file. is that just a bug? in my changeset here, I wrote the file as
though it was a stylus file to avoid formatting differences.

5. I didn't re-generate the minified CSS file. regenerating that file
from master looks like it's significantly different from whatever's
checked in, so I didn't want to add any noise. probably best to handle
whatever's going on there in another branch, assuming there's an issue
there.