### PR TITLE
Improve usability in google chrome extension

### DIFF
--- a/pesticide_for_chrome/manifest.json
+++ b/pesticide_for_chrome/manifest.json
@@ -7,7 +7,16 @@
   "version": "0.3",
 
   "permissions": [
-      "activeTab"
+      "activeTab",
+      "tabs"
+  ],
+
+  "content_scripts": [
+      {
+          "matches": ["*://*/*"],
+          "js": ["pesticide_page.js"],
+          "run_at": "document_end"
+      }
   ],
 
   "background": {

--- a/pesticide_for_chrome/manifest.json
+++ b/pesticide_for_chrome/manifest.json
@@ -4,7 +4,7 @@
   "name": "Pesticide for Chrome",
   "short_name": "Pesticide",
   "description": "This extension inserts the Pesticide CSS into the current page, outlining each element to better see placement on the page.",
-  "version": "0.3",
+  "version": "0.4",
 
   "permissions": [
       "activeTab",

--- a/pesticide_for_chrome/pesticide.js
+++ b/pesticide_for_chrome/pesticide.js
@@ -3,6 +3,7 @@
 chrome.browserAction.onClicked.addListener(function(tab) {
 
     chrome.tabs.executeScript({
-        code: 'var pesticideLink; (document.getElementById("pesticide") == null) ? (pesticideLink = document.createElement("link"), pesticideLink.href = chrome.extension.getURL("/pesticide.min.css"), pesticideLink.id = "pesticide", pesticideLink.type = "text/css", pesticideLink.rel = "stylesheet",document.getElementsByTagName("head")[0].appendChild(pesticideLink)) : (document.getElementsByTagName("head")[0].removeChild(document.getElementById("pesticide")))'
+        code: '_pesticide.state = !_pesticide.state'
     });
+
 });

--- a/pesticide_for_chrome/pesticide_page.js
+++ b/pesticide_for_chrome/pesticide_page.js
@@ -1,0 +1,25 @@
+window._pesticide = { state: localStorage._pesticide == 'true' };
+
+var update = function (show) {
+    var pesticideLink = document.getElementById("pesticide") || null,
+        head = document.getElementsByTagName("head")[0];
+
+    if (show) {
+        pesticideLink = document.createElement("link");
+        pesticideLink.href = chrome.extension.getURL("/pesticide.min.css"); pesticideLink.id = "pesticide";
+        pesticideLink.type = "text/css";
+        pesticideLink.rel = "stylesheet";
+        head.appendChild(pesticideLink);
+    } else {
+        if (pesticideLink)
+            head.removeChild(document.getElementById("pesticide"));
+    }
+};
+
+Object.observe(_pesticide, function (changes) {
+    var newVal = changes[0].object.state;
+    localStorage._pesticide = newVal;
+    update(newVal);
+});
+
+update(window._pesticide.state);


### PR DESCRIPTION
When we activate pesticide on any page, we save the state of the pesticide in localstorage. And then when we come back to the page when the pesticide state is true, we automatically activate the pesticide.