### PR TITLE
fix: prevent event.target.PROP.toString() "not a fn" error

### DIFF
--- a/pesticide_for_chrome/pesticide.js
+++ b/pesticide_for_chrome/pesticide.js
@@ -5,11 +5,11 @@ function init() {
 
 // updates the info banner at the bottom of the page
 function updateBanner(event) {
-  var id = event.target.id.toString() || '';
-  var classList = event.target.classList.toString() || '';
-  var node = event.target.nodeName.toLowerCase() || '';
+  var id = (event.target.id && event.target.id.toString()) || '';
+  var classList = (event.target.classList && event.target.classList.toString()) || '';
+  var node = (event.target.nodeName && event.target.nodeName.toLowerCase()) || '';
 
-  if (!!!resultBanner)
+  if (!resultBanner)
     return false;
 
   // combine the node name, classes, and id into a string in the banner


### PR DESCRIPTION
Using pesticide with Hot Module Replacement sometimes throws due to event.target.id being undefined, in which toString() doesn't exist.

The error is caught and prevents any further JS from processing - incredibly irritating.
Also seemed to persist after toggling off pesticide - until the relevant tab is completely closed.

Added extra checks for event.target.PROP so as not to throw regardless.