### PR TITLE
Iframe support

### DIFF
--- a/pesticide_for_chrome/pesticide-injector.js
+++ b/pesticide_for_chrome/pesticide-injector.js
@@ -2,44 +2,8 @@
 
   'use strict';
 
-  // inject the pesticide CSS and JS
-  function toggleAssets(tab) {
-    var injector = '';
-
-    // logic test if the injected assets exists
-    injector += 'if (document.getElementById("pesticideCSS") && document.getElementById("pesticideJS") ) {';
-
-    //if they exist, remove them
-    injector += 'document.getElementsByTagName("head")[0].removeChild(document.getElementById("pesticideCSS"));';
-    injector += 'document.getElementsByTagName("head")[0].removeChild(document.getElementById("pesticideJS"));';
-    injector += 'document.getElementsByTagName("body")[0].removeChild(document.getElementById("pesticide-for-chrome-result"));';
-
-    //if they don't exist, inject them
-    injector += '} else {';
-
-    injector += 'pesticideCSS = document.createElement("link");';
-    injector += 'pesticideCSS.rel = "stylesheet";';
-    injector += 'pesticideCSS.type = "text/css";';
-    injector += 'pesticideCSS.href = chrome.extension.getURL("/pesticide.min.css");';
-    injector += 'pesticideCSS.id = "pesticideCSS";';
-    injector += 'document.getElementsByTagName("head")[0].appendChild(pesticideCSS);';
-    injector += 'pesticideJS = document.createElement("script");';
-    injector += 'pesticideJS.type = "text/javascript";';
-    injector += 'pesticideJS.src = chrome.extension.getURL("/pesticide.js");';
-    injector += 'pesticideJS.id = "pesticideJS";';
-    injector += 'document.getElementsByTagName("head")[0].appendChild(pesticideJS);';
-    injector += 'pesticideResult = document.createElement("div"),';
-    injector += 'pesticideResult.id = "pesticide-for-chrome-result",';
-    injector += 'document.getElementsByTagName("body")[0].appendChild(pesticideResult)';
-
-    //close logic test
-    injector += '}';
-
-    chrome.tabs.executeScript({code: injector});
-  }
-
   chrome.browserAction.onClicked.addListener(function(tab){
-    toggleAssets(tab);
+    chrome.tabs.executeScript({file: 'pesticide-toggle.js'});
   });
 
 }(window, document));

--- a/pesticide_for_chrome/pesticide-toggle.js
+++ b/pesticide_for_chrome/pesticide-toggle.js
@@ -1,0 +1,20 @@
+if (document.getElementById("pesticideCSS") && document.getElementById("pesticideJS")) {
+  document.getElementsByTagName("head")[0].removeChild(document.getElementById("pesticideCSS"));
+  document.getElementsByTagName("head")[0].removeChild(document.getElementById("pesticideJS"));
+  document.getElementsByTagName("body")[0].removeChild(document.getElementById("pesticide-for-chrome-result"));
+} else {
+  pesticideCSS = document.createElement("link");
+  pesticideCSS.rel = "stylesheet";
+  pesticideCSS.type = "text/css";
+  pesticideCSS.href = chrome.extension.getURL("/pesticide.min.css");
+  pesticideCSS.id = "pesticideCSS";
+  document.getElementsByTagName("head")[0].appendChild(pesticideCSS);
+  pesticideJS = document.createElement("script");
+  pesticideJS.type = "text/javascript";
+  pesticideJS.src = chrome.extension.getURL("/pesticide.js");
+  pesticideJS.id = "pesticideJS";
+  document.getElementsByTagName("head")[0].appendChild(pesticideJS);
+  pesticideResult = document.createElement("div"),
+  pesticideResult.id = "pesticide-for-chrome-result",
+  document.getElementsByTagName("body")[0].appendChild(pesticideResult)
+}

--- a/pesticide_for_chrome/pesticide-toggle.js
+++ b/pesticide_for_chrome/pesticide-toggle.js
@@ -1,20 +1,28 @@
-if (document.getElementById("pesticideCSS") && document.getElementById("pesticideJS")) {
-  document.getElementsByTagName("head")[0].removeChild(document.getElementById("pesticideCSS"));
-  document.getElementsByTagName("head")[0].removeChild(document.getElementById("pesticideJS"));
-  document.getElementsByTagName("body")[0].removeChild(document.getElementById("pesticide-for-chrome-result"));
-} else {
-  pesticideCSS = document.createElement("link");
-  pesticideCSS.rel = "stylesheet";
-  pesticideCSS.type = "text/css";
-  pesticideCSS.href = chrome.extension.getURL("/pesticide.min.css");
-  pesticideCSS.id = "pesticideCSS";
-  document.getElementsByTagName("head")[0].appendChild(pesticideCSS);
-  pesticideJS = document.createElement("script");
-  pesticideJS.type = "text/javascript";
-  pesticideJS.src = chrome.extension.getURL("/pesticide.js");
-  pesticideJS.id = "pesticideJS";
-  document.getElementsByTagName("head")[0].appendChild(pesticideJS);
-  pesticideResult = document.createElement("div"),
-  pesticideResult.id = "pesticide-for-chrome-result",
-  document.getElementsByTagName("body")[0].appendChild(pesticideResult)
+function toggleAssets(doc) {
+  if (doc.getElementById("pesticideCSS") && doc.getElementById("pesticideJS")) {
+    doc.getElementsByTagName("head")[0].removeChild(doc.getElementById("pesticideCSS"));
+    doc.getElementsByTagName("head")[0].removeChild(doc.getElementById("pesticideJS"));
+    doc.getElementsByTagName("body")[0].removeChild(doc.getElementById("pesticide-for-chrome-result"));
+  } else {
+    pesticideCSS = doc.createElement("link");
+    pesticideCSS.rel = "stylesheet";
+    pesticideCSS.type = "text/css";
+    pesticideCSS.href = chrome.extension.getURL("/pesticide.min.css");
+    pesticideCSS.id = "pesticideCSS";
+    doc.getElementsByTagName("head")[0].appendChild(pesticideCSS);
+    pesticideJS = doc.createElement("script");
+    pesticideJS.type = "text/javascript";
+    pesticideJS.src = chrome.extension.getURL("/pesticide.js");
+    pesticideJS.id = "pesticideJS";
+    doc.getElementsByTagName("head")[0].appendChild(pesticideJS);
+    pesticideResult = doc.createElement("div"),
+    pesticideResult.id = "pesticide-for-chrome-result",
+    doc.getElementsByTagName("body")[0].appendChild(pesticideResult)
+  }
 }
+
+toggleAssets(document)
+Array.from(document.getElementsByTagName('iframe'))
+    .map(frame => frame.contentDocument)
+    .filter(doc => doc) // contentDocument will be null for cross-origin frames
+    .map(toggleAssets)


### PR DESCRIPTION
This PR adds the ability to inject Pesticide styles into iframes.

My particular motivation for this to allow Pesticide to work with the React component development environment [Storybook](https://storybook.js.org/) that uses iframes to contain components. You can test this PR with any public Storybook site like [this one](http://react.carbondesignsystem.com/?selectedKind=RadioButtonGroup&selectedStory=Default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel).

Along the way, I moved the injection script from a line-by-line-concatenated string into a separate JS file where it can have proper indentation, syntax highlighting, etc. I believe this is much more maintainable, especially with the (slightly) increased complexity added by this PR.