### PR TITLE
Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-http://pesticide.io


### PR DESCRIPTION
Since the domain has expired, removing the CNAME will let the site be accessible at mrmrs.github.io/pesticide instead of redirecting to a parked page :+1: